### PR TITLE
Add nonce instead of unsafe-inline for naive-ui

### DIFF
--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -12,6 +12,7 @@ test("check menu items", async ({ page }) => {
   const $menu = page.locator('[data-test-id="page-header-menu"]');
   const menuItems = $menu.getByRole("menuitem");
   const $$menuItems = await menuItems.all();
+  await page.waitForTimeout(500);
   await expect(menuItems).toHaveCount(4);
 
   await expect($$menuItems[0]).toHaveText("Home");
@@ -26,6 +27,7 @@ test("General flow", async ({ page, context, browserName }) => {
   }
 
   await page.goto("/");
+  await page.waitForTimeout(500);
   await page.getByRole("link", { name: "Create Crypto Address" }).click();
   await page.waitForURL("/create-wallets/", { timeout: 1000 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,8 +7,15 @@
   import { PageHeader } from "@/entities/PageHeader";
   import { ParanoidMode } from "@/entities/ParanoidMode";
   import ThemeSwitcher from "@/entities/ThemeSwitcher/ThemeSwitcher.vue";
+  import { addNonceToStyles } from "@/shared/lib/csp/addNonceToStyles";
   import initTracker from "@/shared/lib/tracker/initTracker";
   import PageTemplate from "@/shared/ui/PageTemplate/PageTemplate.vue";
+
+  // [tag-nonce]
+  // Some libs doesn't support nonce, part of logic with workaround
+  // Search by tag in the code
+  const chunksWithoutNonce = ["naive-ui"];
+  addNonceToStyles(import.meta.env.VITE_NONCE, chunksWithoutNonce);
 
   const isDark = useDark() as Ref<boolean>;
   const themeProvider = computed(() => (isDark.value ? darkTheme : null));

--- a/src/shared/lib/csp/addNonceToStyles.ts
+++ b/src/shared/lib/csp/addNonceToStyles.ts
@@ -19,7 +19,18 @@ function isSelectedChunk(chunksWithoutNonce: string[]) {
 
   return !!stack
     ?.split("\n")
-    .map((line) => line.match(/at.*\((http.+?)\)$/)?.[1])
+    .map((line) => {
+      const chromeMatch = line.match(/at.*\((http.+?)\)$/);
+      if (chromeMatch) {
+        return chromeMatch[1];
+      }
+
+      const safariMatch = line.match(/@(http.+?):\d+:\d+/);
+      if (safariMatch) {
+        return safariMatch[1];
+      }
+      return null;
+    })
     .filter((line) => line && pathOfChunks.some((path) => line.includes(path)))
     .length;
 }

--- a/src/shared/lib/csp/addNonceToStyles.ts
+++ b/src/shared/lib/csp/addNonceToStyles.ts
@@ -1,0 +1,61 @@
+const originalAppendChild = Node.prototype.appendChild;
+const originalInsertBefore = Node.prototype.insertBefore;
+
+const assetsFolder =
+  import.meta.env.MODE === "production"
+    ? "/assets/"
+    : "/node_modules/.vite/deps/";
+
+/**
+ * Check if the current chunk is one of those that do not support nonce
+ *
+ * [tag-nonce] Search by tag in the code
+ */
+function isSelectedChunk(chunksWithoutNonce: string[]) {
+  const { stack } = new Error();
+  const pathOfChunks = chunksWithoutNonce.map(
+    (chunk) => window.location.origin + assetsFolder + chunk,
+  );
+
+  return !!stack
+    ?.split("\n")
+    .map((line) => line.match(/at.*\((http.+?)\)$/)?.[1])
+    .filter((line) => line && pathOfChunks.some((path) => line.includes(path)))
+    .length;
+}
+
+/**
+ * Add nonce to style elements that do not have it yet for the selected chunks
+ */
+export function addNonceToStyles(nonce: string, chunksWithoutNonce: string[]) {
+  const addNonceToStyle = (element: Node) => {
+    const isStyleElement = element instanceof HTMLStyleElement;
+    if (!isStyleElement) {
+      return;
+    }
+
+    const hasNonce = element.hasAttribute("nonce");
+    if (hasNonce) {
+      return;
+    }
+
+    if (!isSelectedChunk(chunksWithoutNonce)) {
+      return;
+    }
+
+    element.setAttribute("nonce", nonce);
+  };
+
+  Node.prototype.appendChild = function <T extends Node>(node: T): T {
+    addNonceToStyle(node);
+    return originalAppendChild.call(this, node) as T;
+  };
+
+  Node.prototype.insertBefore = function <T extends Node>(
+    node: T,
+    referenceNode: Node | null,
+  ): T {
+    addNonceToStyle(node);
+    return originalInsertBefore.call(this, node, referenceNode) as T;
+  };
+}


### PR DESCRIPTION

Naive-UI doesn’t support nonce ([link to issue](https://github.com/tusen-ai/naive-ui/issues/6356)), so I made an workaround specifically for this library.

If Naive-UI can’t implement support, then I hope another library will implement a solution ([link to issue](https://github.com/RockiRider/csp/issues/2)) so I can remove this workaround.
